### PR TITLE
Se agrega soporte para próximos años

### DIFF
--- a/lib/controller/v2/holidays.js
+++ b/lib/controller/v2/holidays.js
@@ -1,11 +1,11 @@
 import Joi from 'joi';
 import Boom from 'boom';
-import {get} from 'lodash';
 import chain from 'lib/controller/chain';
 
 import {
   monthly as reduceMonthly,
-  list as reduceList
+  list as reduceList,
+  holidays as reduceHolidays
 } from 'lib/reducers';
 
 import {
@@ -21,8 +21,7 @@ import {
 import holidays, { ref } from 'lib/data/holidays';
 
 const setHolidays = (request, reply) => {
-  let yHolidays = get(holidays, `h${request.year}`);
-  if (!yHolidays) return reply(Boom.notFound());
+  let yHolidays = reduceHolidays(holidays, request.year);
 
   if (request.format === 'mensual'){
     let plain = reduceMonthly(yHolidays);

--- a/lib/data/holidays.js
+++ b/lib/data/holidays.js
@@ -1,4 +1,5 @@
 import ref from './holidays/ref.json';
+import future from './holidays/future.json';
 
 import h2011 from './holidays/2011.json';
 import h2012 from './holidays/2012.json';
@@ -13,6 +14,7 @@ import h2020 from './holidays/2020.json';
 
 export default {
   ref,
+  future,
 
   h2011,
   h2012,

--- a/lib/data/holidays/future.json
+++ b/lib/data/holidays/future.json
@@ -1,0 +1,39 @@
+[{
+  "mes": "enero",
+  "01": "año-nuevo"
+},{
+  "mes": "febrero"
+},{
+  "mes": "marzo",
+  "24": "memoria-verdad-justicia"
+},{
+  "mes": "abril",
+  "02": "veteranos-malvinas",
+  "24": "armenia"
+},{
+  "mes": "mayo",
+  "01": "trabajador",
+  "25": "revolucion-mayo"
+},{
+  "mes": "junio",
+  "17": "martin-guemes",
+  "20": "belgrano"
+},{
+  "mes": "julio",
+  "09": "independencia"
+},{
+  "mes": "agosto",
+  "17": "san-martin"
+},{
+  "mes": "septiembre"
+},{
+  "mes": "octubre",
+  "12": "diversidad"
+},{
+  "mes": "noviembre",
+  "20": "soberania-nacional"
+},{
+  "mes": "diciembre",
+  "08": "inmaculada-maria",
+  "25": "navidad"
+}]

--- a/lib/reducers/holidays.js
+++ b/lib/reducers/holidays.js
@@ -1,0 +1,6 @@
+import { get } from 'lodash';
+
+export default function(holidays, year) {
+  return get(holidays, `h${year}`, holidays.future);
+}
+

--- a/lib/reducers/index.js
+++ b/lib/reducers/index.js
@@ -2,10 +2,12 @@ import holidaysV1 from './holidaysV1';
 import monthly from './monthly';
 import list from './list';
 import festive from './festive';
+import holidays from './holidays';
 
 export default {
   holidaysV1,
   monthly,
   list,
-  festive
+  festive,
+  holidays
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nolaborables",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/reducers/holidays.js
+++ b/test/reducers/holidays.js
@@ -1,0 +1,37 @@
+import chai from 'chai';
+import _ from 'lodash';
+import { holidays } from 'lib/reducers';
+const expect = chai.expect;
+
+const holidaysData = {
+  'h2020': [{
+    "mes": "enero",
+    "01": "año-nuevo"
+  },{
+    "mes": "febrero",
+    "24,25": "carnaval"
+  }],
+  future: [{
+    "mes": "enero",
+    "01": "año-nuevo"
+  }],
+};
+
+describe('#holidays', () => {
+
+  it('must return holidays for the given year', () => {
+    let result = holidays(holidaysData, 2020);
+    expect(result).to.be.an('array');
+    expect(result.length).to.be.equal(holidaysData.h2020.length);
+
+    expect(_.isEqual(result, holidaysData.h2020)).to.be.true;
+  });
+
+  it('must return future common holidays for an undefined year', () => {
+    let result = holidays(holidaysData, 2024);
+    expect(result).to.be.an('array');
+    expect(result.length).to.be.equal(holidaysData.future.length);
+
+    expect(_.isEqual(result, holidaysData.future)).to.be.true;
+  });
+});

--- a/test/reducers/index.js
+++ b/test/reducers/index.js
@@ -3,4 +3,5 @@ describe('Reducers', () => {
   require('./monthly');
   require('./list');
   require('./festive');
+  require('./holidays');
 });


### PR DESCRIPTION
Se manda PR sobre el issue #26 agregando soporte para años futuros.
- Se agregó el archivo `future.json` con los feriados comunes en todos los años. Los feriados pueden modificarse por eso la necesidad de tener un archivo especifico por año.
- Se creó un nuevo reducer que tiene la responsabilidad de devolver los feriados para el año correspondiente o futuro. De esta manera queda la lógica en un solo lugar y es mucho mas fácil de testear e iterar de ser necesario si queremos crear algo dinámico.
- Se agregaron tests para los nuevos casos cumpliendo con 100%  de coverage.

Nota: No se si es necesario sumar soporte a la v1. Avisame y mando sin drama.