### PR TITLE
Remove 24 may holyday

### DIFF
--- a/lib/data/holidays/2021.json
+++ b/lib/data/holidays/2021.json
@@ -17,7 +17,6 @@
 },{
   "mes": "mayo",
   "01": "trabajador",
-  "24": ["fiesta-ayuno-ramadan", "puente-turistico"],
   "25": "revolucion-mayo"
 },{
   "mes": "junio",


### PR DESCRIPTION
This holyday was removed by the goverment
Source: https://argentina.as.com/argentina/2021/05/13/actualidad/1620914269_903436.html