### PR TITLE
24 may government rollback

### DIFF
--- a/lib/data/holidays/2021.json
+++ b/lib/data/holidays/2021.json
@@ -17,6 +17,7 @@
 },{
   "mes": "mayo",
   "01": "trabajador",
+  "24": ["fiesta-ayuno-ramadan", "puente-turistico"],
   "25": "revolucion-mayo"
 },{
   "mes": "junio",


### PR DESCRIPTION
Source: 
https://www.clarin.com/politica/gobierno-restablece-feriado-puente-24-mayo_0_nsTu01i5E.html
https://www.infobae.com/politica/2021/05/20/el-gobierno-restablecera-el-feriado-puente-del-24-de-mayo/
https://www.lanacion.com.ar/politica/marcha-atras-el-gobierno-restablecio-el-feriado-del-24-de-mayo-nid20052021/
https://www.pagina12.com.ar/342895-el-gobierno-restablecio-el-feriado-del-24-de-mayo